### PR TITLE
fix: Semantic search bar (SmolLM3-3B) broken due to missing openai dep and HF_TOKEN config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ TABPFN_ACCESS_TOKEN=your_tabpfn_token_here
 # Alternative environment variable name (both work)
 # TABPFN_TOKEN=your_tabpfn_token_here
 
+# HuggingFace API Configuration (required for semantic search bar)
+# Get your token from: https://huggingface.co/settings/tokens
+# Used by the NL query engine to call SmolLM3-3B for natural language search
+HF_TOKEN=your_huggingface_token_here
+
 # Note: Copy this file to .env and fill in your actual token
 # The .env file should NOT be committed to git (already in .gitignore)
 #

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -9,5 +9,10 @@ TABPFN_ACCESS_TOKEN = "your_tabpfn_token_here"
 # Alternative key name (both work)
 # TABPFN_TOKEN = "your_tabpfn_token_here"
 
+# HuggingFace API Configuration (required for semantic search bar)
+# Get your token from: https://huggingface.co/settings/tokens
+# Used by the NL query engine to call SmolLM3-3B for natural language search
+HF_TOKEN = "your_huggingface_token_here"
+
 # Note: For local development, you can also use .env file
 # For deployed apps on Streamlit Cloud, use the Streamlit Cloud secrets UI

--- a/intuitiveness/data_sources/nl_query.py
+++ b/intuitiveness/data_sources/nl_query.py
@@ -19,7 +19,9 @@ from typing import Dict, List, Any, Optional, Tuple
 from dataclasses import dataclass
 
 # HuggingFace model for NL understanding (OpenAI-compatible API)
-HF_MODEL = "HuggingFaceTB/SmolLM3-3B:hf-inference"
+# Note: :hf-inference provider deprecated models (404/410 errors since mid-2025).
+# Using :novita provider instead — routed through HF, no extra API key needed.
+HF_MODEL = "HuggingFaceTB/SmolLM3-3B:novita"
 HF_BASE_URL = "https://router.huggingface.co/v1"
 
 
@@ -68,7 +70,7 @@ class NLQueryEngine:
             )
 
     def _call_hf_api(self, prompt: str, max_tokens: int = 256) -> str:
-        """Call HuggingFace via OpenAI-compatible API."""
+        """Call HuggingFace via OpenAI-compatible API with provider fallback."""
         from openai import OpenAI
 
         client = OpenAI(
@@ -76,16 +78,26 @@ class NLQueryEngine:
             api_key=self.hf_token,
         )
 
-        completion = client.chat.completions.create(
-            model=HF_MODEL,
-            messages=[
-                {"role": "user", "content": prompt}
-            ],
-            max_tokens=max_tokens,
-            temperature=0.1,  # Low for structured output
-        )
+        # Try primary provider, fall back to sambanova if it fails
+        providers = [HF_MODEL, "HuggingFaceTB/SmolLM3-3B:sambanova"]
+        last_error = None
 
-        return completion.choices[0].message.content or ""
+        for model_id in providers:
+            try:
+                completion = client.chat.completions.create(
+                    model=model_id,
+                    messages=[
+                        {"role": "user", "content": prompt}
+                    ],
+                    max_tokens=max_tokens,
+                    temperature=0.1,  # Low for structured output
+                )
+                return completion.choices[0].message.content or ""
+            except Exception as e:
+                last_error = e
+                continue
+
+        raise last_error
 
     def parse_query(self, user_query: str, schema: Optional[Dict] = None) -> NLQueryResult:
         """

--- a/intuitiveness/data_sources/nl_query.py
+++ b/intuitiveness/data_sources/nl_query.py
@@ -19,10 +19,15 @@ from typing import Dict, List, Any, Optional, Tuple
 from dataclasses import dataclass
 
 # HuggingFace model for NL understanding (OpenAI-compatible API)
-# Note: :hf-inference provider deprecated models (404/410 errors since mid-2025).
-# Using :novita provider instead — routed through HF, no extra API key needed.
-HF_MODEL = "HuggingFaceTB/SmolLM3-3B:novita"
+# 3-stage fallback: hf-inference first, then novita, then sambanova.
+# All routed through HF — no extra API key needed beyond HF_TOKEN.
 HF_BASE_URL = "https://router.huggingface.co/v1"
+HF_PROVIDERS = [
+    "HuggingFaceTB/SmolLM3-3B:hf-inference",  # Stage 1: native HF inference
+    "HuggingFaceTB/SmolLM3-3B:novita",         # Stage 2: novita fallback
+    "HuggingFaceTB/SmolLM3-3B:sambanova",      # Stage 3: sambanova fallback
+]
+HF_MODEL = HF_PROVIDERS[0]  # default for backward compat
 
 
 @dataclass
@@ -70,19 +75,21 @@ class NLQueryEngine:
             )
 
     def _call_hf_api(self, prompt: str, max_tokens: int = 256) -> str:
-        """Call HuggingFace via OpenAI-compatible API with provider fallback."""
+        """Call HuggingFace via OpenAI-compatible API with 3-stage provider fallback."""
+        import logging
         from openai import OpenAI
+
+        logger = logging.getLogger(__name__)
 
         client = OpenAI(
             base_url=HF_BASE_URL,
             api_key=self.hf_token,
         )
 
-        # Try primary provider, fall back to sambanova if it fails
-        providers = [HF_MODEL, "HuggingFaceTB/SmolLM3-3B:sambanova"]
+        # 3-stage fallback: hf-inference → novita → sambanova
         last_error = None
 
-        for model_id in providers:
+        for model_id in HF_PROVIDERS:
             try:
                 completion = client.chat.completions.create(
                     model=model_id,
@@ -94,6 +101,7 @@ class NLQueryEngine:
                 )
                 return completion.choices[0].message.content or ""
             except Exception as e:
+                logger.info(f"Provider {model_id.split(':')[-1]} failed: {e}")
                 last_error = e
                 continue
 
@@ -289,4 +297,5 @@ __all__ = [
     'NLQueryResult',
     'parse_french_query',
     'HF_MODEL',
+    'HF_PROVIDERS',
 ]

--- a/intuitiveness/services/datagouv_client.py
+++ b/intuitiveness/services/datagouv_client.py
@@ -156,7 +156,11 @@ class DataGouvSearchService:
                 self._nl_engine = NLQueryEngine(self._hf_token)
             except ValueError:
                 # No HF token available - NL disabled
-                logger.warning("No HF token - NL query enhancement disabled")
+                logger.warning("No HF_TOKEN found - NL query enhancement disabled. "
+                               "Set HF_TOKEN in .env or .streamlit/secrets.toml")
+                return None
+            except Exception as e:
+                logger.warning(f"NL engine init failed: {e}")
                 return None
         return self._nl_engine
 

--- a/intuitiveness/ui/datagouv_search.py
+++ b/intuitiveness/ui/datagouv_search.py
@@ -918,8 +918,15 @@ def render_search_interface() -> Optional[pd.DataFrame]:
                 nl_result = getattr(service, 'last_nl_result', None)
                 if nl_result:
                     st.session_state["datagouv_nl_keywords"] = nl_result.keywords
+                    st.session_state["datagouv_nl_fallback"] = False
                 else:
                     st.session_state["datagouv_nl_keywords"] = None
+                    # Check if NL was expected but unavailable
+                    nl_engine = service._get_nl_engine()
+                    if nl_engine is None and service._is_natural_language(submitted_query):
+                        st.session_state["datagouv_nl_fallback"] = True
+                    else:
+                        st.session_state["datagouv_nl_fallback"] = False
 
             except DataGouvAPIError:
                 st.session_state[SESSION_KEYS["error"]] = t("search_failed")
@@ -941,6 +948,15 @@ def render_search_interface() -> Optional[pd.DataFrame]:
             nl_keywords = st.session_state.get("datagouv_nl_keywords")
             csv_count = len(csv_datasets)
             total_count = results.total
+
+            # Warn if NL engine was expected but unavailable
+            if st.session_state.get("datagouv_nl_fallback"):
+                st.warning(
+                    "Semantic search (SmolLM3-3B) is unavailable — "
+                    "using basic keyword search instead. "
+                    "Set `HF_TOKEN` in your `.env` or `.streamlit/secrets.toml` "
+                    "to enable natural language understanding."
+                )
 
             if nl_keywords:
                 keywords_display = ", ".join(nl_keywords[:4])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "streamlit>=1.28.0",
     "streamlit-agraph>=0.0.45",
     "requests",
+    "openai>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The NL query engine was silently failing because:
1. openai package was in requirements.txt but missing from pyproject.toml
2. HF_TOKEN was not documented in .env.example or secrets.toml.example
3. No user-facing feedback when NL engine is unavailable

Now shows a warning when semantic search falls back to basic keywords.

https://claude.ai/code/session_01KAUN8rvGdppoviprPoUhP5