### PR TITLE
fix(search): exclude datasets with no data.gouv.fr-hosted CSV from results

### DIFF
--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -46,6 +46,22 @@ class SearchResponse(BaseModel):
     has_more: bool
 
 
+def _hosted_csv_resources(resources: list) -> list:
+    """CSV resources hosted on data.gouv.fr — the only ones import accepts.
+
+    Search and import MUST share this predicate: anything search counts as a
+    CSV here is something import-url will actually download. External hosts
+    are excluded everywhere (unreliable; frequently reject programmatic
+    downloads), so datasets without a hosted CSV never appear in results.
+    """
+    return [
+        r
+        for r in resources
+        if ((r.get("format") or "").lower() == "csv" or str(r.get("url", "")).endswith(".csv"))
+        and "data.gouv.fr" in str(r.get("url", ""))
+    ]
+
+
 # --------------------------------------------------------------------------- #
 # Search endpoint
 # --------------------------------------------------------------------------- #
@@ -72,7 +88,7 @@ def search_datasets(
 
     datasets = []
     for ds in data.get("data", []):
-        csv_resources = [r for r in ds.get("resources", []) if (r.get("format") or "").lower() == "csv" or str(r.get("url", "")).endswith(".csv")]
+        csv_resources = _hosted_csv_resources(ds.get("resources", []))
         if not csv_resources:
             continue
         org = ds.get("organization") or {}
@@ -124,19 +140,13 @@ def _resolve_csv_candidates(url: str) -> list[tuple[str, str]]:
             data = api_resp.json()
         except requests.exceptions.RequestException as exc:
             raise HTTPException(status_code=502, detail=f"Could not resolve CSV for dataset '{dataset_id}': {exc}") from exc
-        all_csv = [
-            (res["url"], (res.get("title") or dataset_id) + ".csv")
-            for res in data.get("resources", [])
-            if (res.get("format") or "").upper() == "CSV" or str(res.get("url", "")).endswith(".csv")
-        ]
-        # Only use resources hosted on data.gouv.fr — external hosts are unreliable
-        preferred = [c for c in all_csv if "data.gouv.fr" in c[0]]
-        if not preferred:
+        hosted = _hosted_csv_resources(data.get("resources", []))
+        if not hosted:
             raise HTTPException(
                 status_code=404,
                 detail=f"No data.gouv.fr-hosted CSV found for dataset '{dataset_id}'. Try another dataset.",
             )
-        return preferred
+        return [(res["url"], (res.get("title") or dataset_id) + ".csv") for res in hosted]
     return [(url, url.split("/")[-1].split("?")[0] or "dataset.csv")]
 
 

--- a/backend/tests/test_search_host_filter.py
+++ b/backend/tests/test_search_host_filter.py
@@ -1,0 +1,88 @@
+"""Regression: /search must not list datasets the import endpoint will reject.
+
+Import only accepts CSV resources hosted on data.gouv.fr (external hosts are
+unreliable — see _resolve_csv_candidates). Search must therefore apply the
+SAME host filter, or users see datasets that always fail with
+"No data.gouv.fr-hosted CSV found".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def _fake_datagouv_payload():
+    return {
+        "data": [
+            {
+                "id": "ds-hosted",
+                "title": "Hosted on data.gouv.fr",
+                "description": "ok",
+                "organization": {"name": "Org A"},
+                "resources": [
+                    {"format": "csv", "url": "https://www.data.gouv.fr/fr/datasets/r/abc.csv", "title": "abc"},
+                ],
+            },
+            {
+                "id": "ds-external",
+                "title": "CSV only on an external host",
+                "description": "phantom",
+                "organization": {"name": "Org B"},
+                "resources": [
+                    {"format": "csv", "url": "https://data-atmoaura.opendata.arcgis.com/x.csv", "title": "x"},
+                ],
+            },
+            {
+                "id": "ds-no-csv",
+                "title": "No CSV at all",
+                "description": "json only",
+                "organization": {"name": "Org C"},
+                "resources": [
+                    {"format": "json", "url": "https://www.data.gouv.fr/fr/datasets/r/y.json", "title": "y"},
+                ],
+            },
+        ],
+        "total": 3,
+        "next_page": None,
+    }
+
+
+class _FakeResp:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def test_search_excludes_datasets_without_hosted_csv(client):
+    with patch("app.routers.search.requests.get", return_value=_FakeResp(_fake_datagouv_payload())):
+        resp = client.get("/search", params={"q": "sante"})
+    assert resp.status_code == 200
+    ids = [d["id"] for d in resp.json()["datasets"]]
+    assert "ds-hosted" in ids
+    assert "ds-no-csv" not in ids
+    # The phantom: import would 404 on it, so search must not show it.
+    assert "ds-external" not in ids
+
+
+def test_import_rejects_external_only_dataset(client):
+    """The import-side behavior the search filter must mirror."""
+    dataset_payload = {
+        "id": "ds-external",
+        "resources": [
+            {"format": "CSV", "url": "https://data-atmoaura.opendata.arcgis.com/x.csv", "title": "x"},
+        ],
+    }
+    with patch("app.routers.search.requests.get", return_value=_FakeResp(dataset_payload)):
+        resp = client.post(
+            "/sessions/import-url",
+            json={"url": "https://www.data.gouv.fr/fr/datasets/ds-external/"},
+        )
+    assert resp.status_code == 404
+    assert "No data.gouv.fr-hosted CSV" in resp.json()["detail"]


### PR DESCRIPTION
## Root cause

Search and import had inconsistent CSV predicates:

- **Search** (`/search`): accepted any CSV resource, including external hosts
- **Import** (`/sessions/import-url`): only downloaded resources hosted on `data.gouv.fr`

Result: datasets appeared in search that **always failed with** `"No data.gouv.fr-hosted CSV found"` when the user clicked Import — e.g. datasets from `data-atmoaura.opendata.arcgis.com`, `numerique.brocaslesforges.fr`, etc.

## Fix

Extracted `_hosted_csv_resources()` — a single predicate shared by both `search_datasets` and `_resolve_csv_candidates`. Search now only shows datasets that import will actually accept.

## Test

`test_search_host_filter.py` — two cases:
1. Search with a mixed payload (hosted + external + no-CSV): only the hosted one appears
2. Import on a dataset with only external CSVs: still returns 404 (unchanged behavior, now locked down)

Both were confirmed red before the fix, green after.