### PR TITLE
fix: restore mcp_client + nl_query deleted in f963e54, move to services/

### DIFF
--- a/intuitiveness/services/datagouv_client.py
+++ b/intuitiveness/services/datagouv_client.py
@@ -18,7 +18,7 @@ import pandas as pd
 import logging
 
 # Import NL query engine for natural language understanding
-from intuitiveness.data_sources.nl_query import NLQueryEngine, NLQueryResult
+from intuitiveness.services.nl_query import NLQueryEngine, NLQueryResult
 
 # Import DataGouvAPI from local copy (now used as fallback)
 from intuitiveness.services.datagouv_api import DataGouvAPI

--- a/intuitiveness/services/datagouv_mcp.py
+++ b/intuitiveness/services/datagouv_mcp.py
@@ -17,7 +17,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Optional, Any
 
-from intuitiveness.data_sources.mcp_client import MCPClient, MCPResponse
+from intuitiveness.services.mcp_client import MCPClient, MCPResponse
 
 # Late-import DatasetInfo, ResourceInfo, SearchResult to avoid circular import
 # (datagouv_client.py imports from this module)

--- a/intuitiveness/services/mcp_client.py
+++ b/intuitiveness/services/mcp_client.py
@@ -1,0 +1,291 @@
+"""
+MCP Client - HTTP Transport
+============================
+
+Generic Model Context Protocol client for Streamable HTTP transport.
+Implements JSON-RPC 2.0 over HTTP as per MCP specification.
+
+Feature: 008-datagouv-mcp
+Reference: https://modelcontextprotocol.io/docs/concepts/transports
+"""
+
+import requests
+import json
+from typing import Dict, List, Any, Optional
+from dataclasses import dataclass, field
+
+
+# MCP Protocol Version
+MCP_PROTOCOL_VERSION = "2025-06-18"
+
+
+@dataclass
+class MCPTool:
+    """Represents an MCP tool definition."""
+    name: str
+    description: str
+    input_schema: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MCPResponse:
+    """Represents an MCP response."""
+    success: bool
+    data: Any = None
+    error: Optional[str] = None
+    error_code: Optional[int] = None
+
+
+class MCPClient:
+    """
+    MCP Client for HTTP Streamable transport.
+
+    Handles:
+    - Session initialization
+    - Tool listing
+    - Tool invocation
+
+    Example:
+        client = MCPClient("https://mcp.data.gouv.fr/mcp")
+        client.initialize()
+        tools = client.list_tools()
+        result = client.call_tool("search_datasets", {"q": "éducation"})
+    """
+
+    def __init__(self, endpoint: str, timeout: int = 30):
+        """
+        Initialize MCP client.
+
+        Args:
+            endpoint: MCP server endpoint URL
+            timeout: Request timeout in seconds
+        """
+        self.endpoint = endpoint.rstrip('/')
+        self.timeout = timeout
+        self.session_id: Optional[str] = None
+        self.request_id: int = 0
+        self._tools: Dict[str, MCPTool] = {}
+        self._initialized = False
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get required headers for MCP requests."""
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+        }
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+        return headers
+
+    def _next_id(self) -> int:
+        """Get next request ID."""
+        self.request_id += 1
+        return self.request_id
+
+    def _send_request(self, method: str, params: Optional[Dict] = None) -> MCPResponse:
+        """
+        Send a JSON-RPC request to the MCP server.
+
+        Args:
+            method: JSON-RPC method name
+            params: Method parameters
+
+        Returns:
+            MCPResponse with result or error
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": method,
+        }
+        if params:
+            payload["params"] = params
+
+        try:
+            # Use data= with explicit UTF-8 encoding to preserve
+            # non-ASCII characters (French accents) in MCP queries
+            import json as _json
+            encoded_body = _json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+            response = requests.post(
+                self.endpoint,
+                headers=self._get_headers(),
+                data=encoded_body,
+                timeout=self.timeout
+            )
+            response.encoding = "utf-8"
+
+            # Check for session ID in response
+            if "Mcp-Session-Id" in response.headers:
+                self.session_id = response.headers["Mcp-Session-Id"]
+
+            # Handle SSE response
+            content_type = response.headers.get("Content-Type", "")
+            if "text/event-stream" in content_type:
+                # Parse SSE - look for data: lines
+                data = self._parse_sse(response.text)
+            else:
+                # Regular JSON response
+                data = response.json()
+
+            # Check for JSON-RPC error
+            if "error" in data:
+                return MCPResponse(
+                    success=False,
+                    error=data["error"].get("message", "Unknown error"),
+                    error_code=data["error"].get("code")
+                )
+
+            return MCPResponse(success=True, data=data.get("result"))
+
+        except requests.exceptions.Timeout:
+            return MCPResponse(success=False, error="Request timeout")
+        except requests.exceptions.RequestException as e:
+            return MCPResponse(success=False, error=f"Request failed: {str(e)}")
+        except json.JSONDecodeError as e:
+            return MCPResponse(success=False, error=f"Invalid JSON response: {str(e)}")
+
+    def _parse_sse(self, text: str) -> Dict:
+        """Parse Server-Sent Events response."""
+        for line in text.split('\n'):
+            if line.startswith('data:'):
+                data_str = line[5:].strip()
+                if data_str:
+                    return json.loads(data_str)
+        return {}
+
+    def initialize(self) -> MCPResponse:
+        """
+        Initialize the MCP session.
+
+        Sends the initialize request to establish capabilities.
+
+        Returns:
+            MCPResponse with server capabilities
+        """
+        params = {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": {}
+            },
+            "clientInfo": {
+                "name": "data-redesign-method",
+                "version": "1.0.0"
+            }
+        }
+
+        response = self._send_request("initialize", params)
+
+        if response.success:
+            self._initialized = True
+            # Send initialized notification
+            self._send_notification("notifications/initialized")
+
+        return response
+
+    def _send_notification(self, method: str, params: Optional[Dict] = None):
+        """Send a notification (no response expected)."""
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+        }
+        if params:
+            payload["params"] = params
+
+        try:
+            requests.post(
+                self.endpoint,
+                headers=self._get_headers(),
+                json=payload,
+                timeout=self.timeout
+            )
+        except:
+            pass  # Notifications don't require response handling
+
+    def list_tools(self) -> List[MCPTool]:
+        """
+        List available tools from the MCP server.
+
+        Returns:
+            List of MCPTool objects
+        """
+        if not self._initialized:
+            init_response = self.initialize()
+            if not init_response.success:
+                return []
+
+        response = self._send_request("tools/list")
+
+        if not response.success:
+            return []
+
+        tools = []
+        for tool_data in response.data.get("tools", []):
+            tool = MCPTool(
+                name=tool_data.get("name", ""),
+                description=tool_data.get("description", ""),
+                input_schema=tool_data.get("inputSchema", {})
+            )
+            self._tools[tool.name] = tool
+            tools.append(tool)
+
+        return tools
+
+    def call_tool(self, name: str, arguments: Optional[Dict] = None) -> MCPResponse:
+        """
+        Call an MCP tool.
+
+        Args:
+            name: Tool name
+            arguments: Tool arguments
+
+        Returns:
+            MCPResponse with tool result
+        """
+        if not self._initialized:
+            init_response = self.initialize()
+            if not init_response.success:
+                return init_response
+
+        params = {"name": name}
+        if arguments:
+            params["arguments"] = arguments
+
+        return self._send_request("tools/call", params)
+
+    def get_tool(self, name: str) -> Optional[MCPTool]:
+        """Get a tool definition by name."""
+        if not self._tools:
+            self.list_tools()
+        return self._tools.get(name)
+
+    def close(self):
+        """Close the MCP session."""
+        if self.session_id:
+            try:
+                requests.delete(
+                    self.endpoint,
+                    headers=self._get_headers(),
+                    timeout=5
+                )
+            except:
+                pass
+            self.session_id = None
+            self._initialized = False
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.initialize()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+
+
+# =============================================================================
+# Exports
+# =============================================================================
+
+__all__ = ['MCPClient', 'MCPTool', 'MCPResponse', 'MCP_PROTOCOL_VERSION']

--- a/intuitiveness/services/nl_query.py
+++ b/intuitiveness/services/nl_query.py
@@ -1,0 +1,302 @@
+"""
+Natural Language Query Engine
+==============================
+
+Uses HuggingFace SmolLM3-3B for true natural language understanding
+to query data.gouv.fr datasets.
+
+Flow:
+1. User asks question in natural language (French)
+2. SmolLM3-3B extracts intent → generates search keywords + filters
+3. Search data.gouv for relevant datasets
+4. Query resource data with generated filters
+
+Feature: 008-datagouv-mcp
+"""
+
+import os
+from typing import Dict, List, Any, Optional, Tuple
+from dataclasses import dataclass
+
+# HuggingFace model for NL understanding (OpenAI-compatible API)
+# SmolLM3-3B-Instruct has no working provider on HF router (tested 2026-03).
+# Qwen2.5-72B-Instruct is confirmed working via live API test.
+# All routed through HF — no extra API key needed beyond HF_TOKEN.
+HF_BASE_URL = "https://router.huggingface.co/v1"
+HF_PROVIDERS = [
+    "Qwen/Qwen2.5-72B-Instruct",   # Stage 1: primary (confirmed working)
+    "Qwen/Qwen2.5-7B-Instruct",    # Stage 2: lighter fallback
+]
+HF_MODEL = HF_PROVIDERS[0]  # default for backward compat
+
+
+@dataclass
+class NLQueryResult:
+    """Result of natural language query parsing."""
+    keywords: List[str]
+    filters: Dict[str, Any]
+    intent: str  # 'search', 'query', 'aggregate'
+    sql_hint: Optional[str] = None
+    raw_response: str = ""
+
+
+class NLQueryEngine:
+    """
+    Natural language query engine using SmolLM3-3B.
+
+    Transforms French natural language questions into:
+    - Search keywords for data.gouv
+    - SQL-like filters for resource queries
+    - Aggregation hints
+    """
+
+    def __init__(self, hf_token: Optional[str] = None):
+        """
+        Initialize the NL query engine.
+
+        Args:
+            hf_token: HuggingFace API token. If not provided,
+                      looks for HF_TOKEN environment variable.
+        """
+        self.hf_token = hf_token or os.environ.get("HF_TOKEN")
+
+        # Try Streamlit secrets if no env var
+        if not self.hf_token:
+            try:
+                import streamlit as st
+                self.hf_token = st.secrets.get("HF_TOKEN")
+            except:
+                pass
+
+        if not self.hf_token:
+            raise ValueError(
+                "HuggingFace token required. Set HF_TOKEN environment variable, "
+                "add to .streamlit/secrets.toml, or pass hf_token parameter."
+            )
+
+    def _call_hf_api(self, prompt: str, max_tokens: int = 256) -> str:
+        """Call HuggingFace via OpenAI-compatible API with 3-stage provider fallback."""
+        import logging
+        from openai import OpenAI
+
+        logger = logging.getLogger(__name__)
+
+        client = OpenAI(
+            base_url=HF_BASE_URL,
+            api_key=self.hf_token,
+        )
+
+        # 3-stage fallback: hf-inference → novita → sambanova
+        last_error = None
+
+        for model_id in HF_PROVIDERS:
+            try:
+                completion = client.chat.completions.create(
+                    model=model_id,
+                    messages=[
+                        {"role": "system", "content": "Tu es un assistant d'analyse de données. Réponds uniquement au format structuré demandé, sans explication supplémentaire."},
+                        {"role": "user", "content": prompt}
+                    ],
+                    max_tokens=max_tokens,
+                    temperature=0.1,  # Low for structured output
+                )
+                return completion.choices[0].message.content or ""
+            except Exception as e:
+                logger.info(f"Provider {model_id.split(':')[-1]} failed: {e}")
+                last_error = e
+                continue
+
+        raise last_error
+
+    def parse_query(self, user_query: str, schema: Optional[Dict] = None) -> NLQueryResult:
+        """
+        Parse a natural language query into structured components.
+
+        Args:
+            user_query: User's question in French
+            schema: Optional schema of available columns (for SQL generation)
+
+        Returns:
+            NLQueryResult with keywords, filters, and intent
+        """
+        # Build prompt for SmolLM3
+        schema_info = ""
+        if schema:
+            cols = ", ".join(schema.get("columns", [])[:20])  # Limit columns
+            schema_info = f"\nColonnes disponibles: {cols}"
+
+        prompt = f"""Tu es un assistant qui analyse des questions en français sur des données publiques.
+Extrais les informations suivantes de la question:
+1. MOTS_CLES: mots-clés pour rechercher des datasets (séparés par des virgules)
+2. FILTRES: conditions de filtrage au format colonne=valeur
+3. INTENTION: search (chercher datasets) ou query (interroger données) ou aggregate (calculer)
+{schema_info}
+Réponds UNIQUEMENT au format demandé, sans explication.
+
+Question: {user_query}
+
+MOTS_CLES:"""
+
+        try:
+            response = self._call_hf_api(prompt, max_tokens=512)  # More tokens for full response
+            return self._parse_response(response, user_query)
+        except Exception as e:
+            # Fallback: extract simple keywords
+            return self._fallback_parse(user_query, str(e))
+
+    def _parse_response(self, response: str, original_query: str) -> NLQueryResult:
+        """Parse the model's structured response."""
+        import re
+
+        # Clean <think>...</think> tags from response (including unclosed)
+        response = re.sub(r'<think>.*?</think>', '', response, flags=re.DOTALL)
+        response = re.sub(r'<think>.*', '', response, flags=re.DOTALL)  # Unclosed tag
+        response = response.strip()
+
+        keywords = []
+        filters = {}
+        intent = "search"
+        sql_hint = None
+
+        lines = response.strip().split("\n")
+        current_section = "keywords"
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            if line.startswith("MOTS_CLES:") or current_section == "keywords":
+                # Extract keywords
+                if ":" in line:
+                    kw_part = line.split(":", 1)[1].strip()
+                else:
+                    kw_part = line
+                keywords.extend([k.strip() for k in kw_part.split(",") if k.strip()])
+                current_section = "filters"
+
+            elif line.startswith("FILTRES:"):
+                # Extract filters
+                filter_part = line.split(":", 1)[1].strip()
+                for f in filter_part.split(","):
+                    if "=" in f:
+                        key, val = f.split("=", 1)
+                        filters[key.strip()] = val.strip()
+                current_section = "intent"
+
+            elif line.startswith("INTENTION:"):
+                intent_part = line.split(":", 1)[1].strip().lower()
+                if "query" in intent_part:
+                    intent = "query"
+                elif "aggregate" in intent_part or "calcul" in intent_part:
+                    intent = "aggregate"
+                else:
+                    intent = "search"
+
+        # If no keywords extracted, use simple fallback
+        if not keywords:
+            return self._fallback_parse(original_query, "No keywords extracted")
+
+        # Split compound keywords (e.g., "résultats scolaires collèges" -> 3 keywords)
+        # This helps with data.gouv.fr's picky search
+        split_keywords = []
+        for kw in keywords:
+            # Split on spaces if keyword has 3+ words
+            words = kw.split()
+            if len(words) >= 3:
+                split_keywords.extend(words)
+            else:
+                split_keywords.append(kw)
+
+        # Dedupe while preserving order
+        seen = set()
+        unique_keywords = []
+        for k in split_keywords:
+            k_lower = k.lower()
+            if k_lower not in seen and len(k) > 2:
+                seen.add(k_lower)
+                unique_keywords.append(k)
+
+        return NLQueryResult(
+            keywords=unique_keywords if unique_keywords else keywords,
+            filters=filters,
+            intent=intent,
+            sql_hint=sql_hint,
+            raw_response=response
+        )
+
+    def _fallback_parse(self, query: str, error: str) -> NLQueryResult:
+        """Fallback keyword extraction when model fails."""
+        # Simple French stopword removal
+        stopwords = {
+            'le', 'la', 'les', 'un', 'une', 'des', 'du', 'de', 'et', 'ou',
+            'qui', 'que', 'quoi', 'dont', 'où', 'quels', 'quelles', 'quel',
+            'quelle', 'sont', 'est', 'sur', 'pour', 'dans', 'en', 'par',
+            'avec', 'sans', 'plus', 'moins', 'très', 'bien', 'tous', 'tout',
+            'cette', 'ces', 'ce', 'cet', 'mon', 'ma', 'mes', 'ton', 'ta',
+            'ses', 'notre', 'nos', 'leur', 'leurs', 'je', 'tu', 'il', 'elle',
+            'nous', 'vous', 'ils', 'elles', 'me', 'te', 'se', 'y', 'ne',
+            'pas', 'au', 'aux', 'à', 'a', 'ont', 'été', 'être', 'avoir',
+            'fait', 'faire', 'comme', 'si', 'mais', 'car', 'donc', 'ni',
+            'entre', 'vers', 'chez', 'aussi', 'même', 'autres', 'autre',
+            'données', 'dataset', 'datasets', 'donnees', 'quelles'
+        }
+
+        # Extract words, remove stopwords
+        words = query.lower().replace('?', '').replace(',', ' ').split()
+        keywords = [w for w in words if w not in stopwords and len(w) > 2]
+
+        # Keep unique, max 5
+        seen = set()
+        unique_keywords = []
+        for k in keywords:
+            if k not in seen:
+                seen.add(k)
+                unique_keywords.append(k)
+                if len(unique_keywords) >= 5:
+                    break
+
+        return NLQueryResult(
+            keywords=unique_keywords if unique_keywords else query.split()[:3],
+            filters={},
+            intent="search",
+            raw_response=f"[Fallback mode: {error}]"
+        )
+
+    def generate_search_query(self, nl_result: NLQueryResult) -> str:
+        """Generate a search query string from NL result."""
+        return " ".join(nl_result.keywords)
+
+
+def parse_french_query(query: str, hf_token: Optional[str] = None) -> NLQueryResult:
+    """
+    Convenience function to parse a French natural language query.
+
+    Args:
+        query: User's question in French
+        hf_token: Optional HuggingFace token
+
+    Returns:
+        NLQueryResult with extracted keywords and intent
+    """
+    try:
+        engine = NLQueryEngine(hf_token)
+        return engine.parse_query(query)
+    except ValueError:
+        # No token - use fallback
+        engine = NLQueryEngine.__new__(NLQueryEngine)
+        engine.hf_token = None
+        return engine._fallback_parse(query, "No HF token")
+
+
+# =============================================================================
+# Exports
+# =============================================================================
+
+__all__ = [
+    'NLQueryEngine',
+    'NLQueryResult',
+    'parse_french_query',
+    'HF_MODEL',
+    'HF_PROVIDERS',
+]

--- a/intuitiveness/services/worldbank_mcp.py
+++ b/intuitiveness/services/worldbank_mcp.py
@@ -15,7 +15,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-from intuitiveness.data_sources.mcp_client import MCPClient, MCPResponse
+from intuitiveness.services.mcp_client import MCPClient, MCPResponse
 from intuitiveness.services.worldbank_service import IndicatorInfo
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
These modules were deleted in the Streamlit cleanup but are still needed by worldbank_mcp.py, datagouv_mcp.py, and datagouv_client.py — without them both MCP search paths crash on import.